### PR TITLE
Fix edit command for reviews

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -30,6 +30,7 @@ import seedu.address.model.restaurant.Phone;
 import seedu.address.model.restaurant.Restaurant;
 import seedu.address.model.restaurant.Weblink;
 import seedu.address.model.restaurant.categories.Cuisine;
+import seedu.address.model.review.Review;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -114,8 +115,12 @@ public class EditCommand extends Command {
 
         Optional<Cuisine> updatedCuisine = restaurantToEdit.getCuisine();
 
+        //Ensures that reviews are copied over exactly, because they are not modified by this command.
+        Set<Review> sameReviews = new HashSet<>();
+        sameReviews.addAll(restaurantToEdit.getReviews());
+
         return new Restaurant(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags,
-                updatedWeblink, updatedOpeninghours, updatedCuisine);
+                updatedWeblink, updatedOpeninghours, updatedCuisine, sameReviews);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -30,6 +30,7 @@ import seedu.address.model.restaurant.Phone;
 import seedu.address.model.restaurant.Restaurant;
 import seedu.address.model.restaurant.Weblink;
 import seedu.address.model.restaurant.categories.Cuisine;
+import seedu.address.model.review.Review;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -114,8 +115,12 @@ public class EditCommand extends Command {
 
         Optional<Cuisine> updatedCuisine = restaurantToEdit.getCuisine();
 
+        //Ensures that reviews are copied over, because reviews cannot be edited with this command.
+        Set<Review> sameReviews = new HashSet<>();
+        sameReviews.addAll(restaurantToEdit.getReviews());
+
         return new Restaurant(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags,
-                updatedWeblink, updatedOpeninghours, updatedCuisine);
+                updatedWeblink, updatedOpeninghours, updatedCuisine, sameReviews);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -30,7 +30,6 @@ import seedu.address.model.restaurant.Phone;
 import seedu.address.model.restaurant.Restaurant;
 import seedu.address.model.restaurant.Weblink;
 import seedu.address.model.restaurant.categories.Cuisine;
-import seedu.address.model.review.Review;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -115,12 +114,8 @@ public class EditCommand extends Command {
 
         Optional<Cuisine> updatedCuisine = restaurantToEdit.getCuisine();
 
-        //Ensures that reviews are copied over, because reviews cannot be edited with this command.
-        Set<Review> sameReviews = new HashSet<>();
-        sameReviews.addAll(restaurantToEdit.getReviews());
-
         return new Restaurant(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags,
-                updatedWeblink, updatedOpeninghours, updatedCuisine, sameReviews);
+                updatedWeblink, updatedOpeninghours, updatedCuisine);
     }
 
     @Override


### PR DESCRIPTION
Included reviews to be copied to the edited restaurant in EditCommand. Previously, reviews in the existing restaurant were not copied over when EditCommand was executed.